### PR TITLE
Adding new hook class to support order-sign

### DIFF
--- a/src/main/java/org/opencds/cqf/cds/hooks/HookFactory.java
+++ b/src/main/java/org/opencds/cqf/cds/hooks/HookFactory.java
@@ -11,6 +11,7 @@ public class HookFactory {
             case "medication-prescribe": return new MedicationPrescribeHook(request);
             case "order-review": return new OrderReviewHook(request);
             case "order-select": return new OrderSelectHook(request);
+            case "order-sign": return new OrderSignHook(request);
             default: throw new InvalidHookException("Unknown Hook: " + request.getHook());
         }
     }

--- a/src/main/java/org/opencds/cqf/cds/hooks/OrderSignHook.java
+++ b/src/main/java/org/opencds/cqf/cds/hooks/OrderSignHook.java
@@ -1,0 +1,17 @@
+package org.opencds.cqf.cds.hooks;
+
+import org.opencds.cqf.cds.request.JsonHelper;
+import org.opencds.cqf.cds.request.Request;
+import com.google.gson.JsonElement;
+
+public class OrderSignHook extends Hook {
+
+    public OrderSignHook(Request request) {
+        super(request);
+    }
+
+    @Override
+    public JsonElement getContextResources() {
+        return JsonHelper.getObjectRequired(getRequest().getContext().getContextJson(), "draftOrders");
+    }
+}


### PR DESCRIPTION
As the "order-review" hook is now deprecated (see https://cds-hooks.org/hooks/order-review/), I have updated the HookFactory to support the "order-sign" hook.